### PR TITLE
Add libglew-dev to the list of native libraries

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -8,6 +8,7 @@ libalut-dev
 libblas-dev
 libbrotli-dev
 libevdev-dev
+libglew-dev
 libicu-dev
 liblapack-dev
 liblzma-dev


### PR DESCRIPTION
One package I depend on and my own package require `libglew-dev` to build successfully. Is it possible to have it added to the native libraries exposed by Hackage builds?

Just in case, the package I depend on is [nanovg](https://hackage.haskell.org/package/nanovg), and this is the [build failure](https://hackage.haskell.org/package/nanovg-0.7.0.0/reports/1). My package is [monomer](https://hackage.haskell.org/package/monomer).

Thanks!