### PR TITLE
Added libgsl-dev to packages.txt

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -9,6 +9,7 @@ libblas-dev
 libbrotli-dev
 libevdev-dev
 libglew-dev
+libgsl-dev
 libicu-dev
 liblapack-dev
 liblzma-dev


### PR DESCRIPTION
My libraries goal-core, goal-geometry, goal-probability, and goal-graphical don't build on hackage, because they depend on hmatrix-gsl which requires the gsl c libs. Hopefully this should address that. This should also be useful to many who are doing numerics stuff with Haskell.