### PR TITLE
Add `libasound-dev` to packages.txt

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -5,6 +5,7 @@ c2hs
 freeglut3-dev
 freetds-dev
 libalut-dev
+libasound-dev
 libblas-dev
 libbrotli-dev
 libbz2-dev


### PR DESCRIPTION
Helpful for [PortMidi](https://hackage.haskell.org/package/PortMidi). Note that CI currently actually passes for PortMidi (Hackage infrastructure was different in 2018, I guess), but not for packages which depend upon it and have been uploaded more recently, such as [Euterpea](https://hackage.haskell.org/package/Euterpea).