### PR TITLE
Add libzmq3-dev

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -21,5 +21,6 @@ libsdl2-dev
 libssl-dev
 libtinfo-dev
 libxft-dev
+libzmq3-dev
 lzma-dev
 zlib1g-dev


### PR DESCRIPTION
To build documentation for `ihaskell` package, which is currently unbuildable otherwise:
https://hackage.haskell.org/package/ihaskell-0.10.2.2/reports/2

Seems reasonably lightweight to me, e. g., 
```
$ apt install libzmq3-dev
The following NEW packages will be installed:
  libnorm1 libpgm-5.2-0 libzmq3-dev libzmq5
Need to get 1,002 kB of archives.
After this operation, 3,766 kB of additional disk space will be used.
```