### PR TITLE
Add glfw3

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -10,6 +10,7 @@ libbrotli-dev
 libbz2-dev
 libevdev-dev
 libglew-dev
+libglfw3-dev
 libgsl-dev
 libicu-dev
 liblapack-dev


### PR DESCRIPTION
A lightweight alternative to SDL, concerned only with window contexts.

Used by [GLFW-b et al](https://hackage.haskell.org/package/GLFW-b/reverse).