### PR TITLE
Update packages.txt to add libhdf5-dev

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -11,6 +11,7 @@ libbz2-dev
 libevdev-dev
 libglew-dev
 libgsl-dev
+libhdf5-dev
 libicu-dev
 liblapack-dev
 liblzma-dev


### PR DESCRIPTION
This dependecy is required in order to build the hdf5 documentation