### PR TITLE
Use postgresql in the build dependencies to get the pg_config output

### DIFF
--- a/build-depends.nix
+++ b/build-depends.nix
@@ -64,6 +64,7 @@ with pkgs; [
   pcre # regex-pcre
   pcre2 # simple-cairo
   postgresql.lib
+  postgresql.pg_config
   sdl3
   systemdMinimal # hidapi requires udev
   util-linux # simple-pango requires mount

--- a/build-depends.nix
+++ b/build-depends.nix
@@ -63,8 +63,7 @@ with pkgs; [
   pango # simple-pango
   pcre # regex-pcre
   pcre2 # simple-cairo
-  postgresql.lib
-  postgresql.pg_config
+  postgresql
   sdl3
   systemdMinimal # hidapi requires udev
   util-linux # simple-pango requires mount


### PR DESCRIPTION
In order to fix building packages that require libpq.